### PR TITLE
propose update verticalWindProfile

### DIFF
--- a/InitWindField.py
+++ b/InitWindField.py
@@ -2809,9 +2809,10 @@ def getVerticalProfile( cursor,
         verticalProfileAbove = pd.Series([V_ref * np.log((z - d) / z0) / np.log(z_ref / z0)
                                                      for z in pointHeighAbove],
                                           index = pointHeighAbove)
-        verticalWindProfile = verticalProfileWithin\
-            .append(verticalProfileAbove[verticalProfileAbove > verticalProfileWithin.max()])\
-                .reindex(pointHeightIndex).interpolate(method = "index")
+        verticalWindProfile = pd.concat(
+            [verticalProfileWithin, verticalProfileAbove[verticalProfileAbove > verticalProfileWithin.max()]],
+            ignore_index=True).reindex(pointHeightIndex).interpolate(method="index")
+	
     elif profileType == "user":
         pointHeightIndex = pd.Index(pointHeightList)
         verticalWindProfile = pd.read_csv(verticalProfileFile, header = None, 


### PR DESCRIPTION
I propose to change line 2856 and use pd.concat instead of append '''
/InitWindField.py:2856: FutureWarning: The series.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  .append(verticalProfileAbove[verticalProfileAbove > verticalProfileWithin.max()]) \
'''