### PR TITLE
Raise errors

### DIFF
--- a/H2gisConnection.py
+++ b/H2gisConnection.py
@@ -264,9 +264,12 @@ def identifyJavaDir(java_path_os_list):
     i = 0
     # Test some common folder paths to check whether a Java installation exists and stops once found
     while(not (JavaExists or i >= len(java_path_os_list))):
+        print(i)
         javaBaseDir = java_path_os_list[i]
         JavaExists = os.path.exists(javaBaseDir)
         i += 1
+    print(javaBaseDir)
+    print(JavaExists)
     if JavaExists:
         listJavaVersion = os.listdir(javaBaseDir)
         listSplit = pd.Series({i: re.split('\.|\-', v) for i, v in enumerate(listJavaVersion)})
@@ -280,5 +283,8 @@ def identifyJavaDir(java_path_os_list):
         javaPath = os.path.join(javaBaseDir, listJavaVersion[highestVersion])
     else:
         javaPath = None
+    
+    
+    print(javaPath)
     
     return javaPath

--- a/H2gisConnection.py
+++ b/H2gisConnection.py
@@ -197,7 +197,7 @@ def getJavaDir(pluginDirectory):
                 JAVA variable path"""
     javaPath = os.environ.get("JAVA_HOME")
     javaPathFile = os.path.join(pluginDirectory, JAVA_PATH_FILENAME)
-    
+    print(javaPathFile)
     # For some reason, JAVA_HOME may be set to %JAVA_HOME% while there is no
     # Java home set. This should be associated to None
     if javaPath:

--- a/H2gisConnection.py
+++ b/H2gisConnection.py
@@ -197,10 +197,11 @@ def getJavaDir(pluginDirectory):
                 JAVA variable path"""
     javaPath = os.environ.get("JAVA_HOME")
     javaPathFile = os.path.join(pluginDirectory, JAVA_PATH_FILENAME)
-    
+    print("javaPath is :" + javaPath)
     # For some reason, JAVA_HOME may be set to %JAVA_HOME% while there is no
     # Java home set. This should be associated to None
     if javaPath:
+        print("crazy bug ?")
         if javaPath[0] == "%":
             javaPath == None
     if not javaPath:
@@ -208,7 +209,9 @@ def getJavaDir(pluginDirectory):
             javaFilePath = open(javaPathFile, "r")
             javaPath = javaFilePath.read()
             javaFilePath.close()
+            print("Java file exists..." + javaPath)
         else:
+            print("Java file does not exist")
             os_type = os.name
             if os_type == "posix":
                 javaPath = identifyJavaDir(JAVA_PATH_POSIX)
@@ -268,8 +271,8 @@ def identifyJavaDir(java_path_os_list):
         javaBaseDir = java_path_os_list[i]
         JavaExists = os.path.exists(javaBaseDir)
         i += 1
-    print(javaBaseDir)
-    print(JavaExists)
+    print("javaBaseDir is : " + javaBaseDir)
+    print("JavaExists is : " + JavaExists)
     if JavaExists:
         listJavaVersion = os.listdir(javaBaseDir)
         listSplit = pd.Series({i: re.split('\.|\-', v) for i, v in enumerate(listJavaVersion)})

--- a/H2gisConnection.py
+++ b/H2gisConnection.py
@@ -197,7 +197,7 @@ def getJavaDir(pluginDirectory):
                 JAVA variable path"""
     javaPath = os.environ.get("JAVA_HOME")
     javaPathFile = os.path.join(pluginDirectory, JAVA_PATH_FILENAME)
-    print(javaPathFile)
+    
     # For some reason, JAVA_HOME may be set to %JAVA_HOME% while there is no
     # Java home set. This should be associated to None
     if javaPath:
@@ -263,7 +263,7 @@ def identifyJavaDir(java_path_os_list):
     JavaExists = False
     i = 0
     # Test some common folder paths to check whether a Java installation exists and stops once found
-    while(not JavaExists and i < len(java_path_os_list)):
+    while(not JavaExists or i < len(java_path_os_list)):
         javaBaseDir = java_path_os_list[i]
         JavaExists = os.path.exists(javaBaseDir)
         i += 1

--- a/H2gisConnection.py
+++ b/H2gisConnection.py
@@ -263,7 +263,7 @@ def identifyJavaDir(java_path_os_list):
     JavaExists = False
     i = 0
     # Test some common folder paths to check whether a Java installation exists and stops once found
-    while(not JavaExists or i < len(java_path_os_list)):
+    while(not (JavaExists or i >= len(java_path_os_list))):
         javaBaseDir = java_path_os_list[i]
         JavaExists = os.path.exists(javaBaseDir)
         i += 1

--- a/H2gisConnection.py
+++ b/H2gisConnection.py
@@ -197,11 +197,9 @@ def getJavaDir(pluginDirectory):
                 JAVA variable path"""
     javaPath = os.environ.get("JAVA_HOME")
     javaPathFile = os.path.join(pluginDirectory, JAVA_PATH_FILENAME)
-    print("javaPath is :" + javaPath)
     # For some reason, JAVA_HOME may be set to %JAVA_HOME% while there is no
     # Java home set. This should be associated to None
     if javaPath:
-        print("crazy bug ?")
         if javaPath[0] == "%":
             javaPath == None
     if not javaPath:
@@ -209,9 +207,7 @@ def getJavaDir(pluginDirectory):
             javaFilePath = open(javaPathFile, "r")
             javaPath = javaFilePath.read()
             javaFilePath.close()
-            print("Java file exists..." + javaPath)
         else:
-            print("Java file does not exist")
             os_type = os.name
             if os_type == "posix":
                 javaPath = identifyJavaDir(JAVA_PATH_POSIX)
@@ -267,12 +263,9 @@ def identifyJavaDir(java_path_os_list):
     i = 0
     # Test some common folder paths to check whether a Java installation exists and stops once found
     while(not (JavaExists or i >= len(java_path_os_list))):
-        print(i)
         javaBaseDir = java_path_os_list[i]
         JavaExists = os.path.exists(javaBaseDir)
         i += 1
-    print("javaBaseDir is : " + javaBaseDir)
-    print("JavaExists is : " + JavaExists)
     if JavaExists:
         listJavaVersion = os.listdir(javaBaseDir)
         listSplit = pd.Series({i: re.split('\.|\-', v) for i, v in enumerate(listJavaVersion)})
@@ -286,8 +279,5 @@ def identifyJavaDir(java_path_os_list):
         javaPath = os.path.join(javaBaseDir, listJavaVersion[highestVersion])
     else:
         javaPath = None
-    
-    
-    print(javaPath)
     
     return javaPath

--- a/H2gisConnection.py
+++ b/H2gisConnection.py
@@ -262,19 +262,23 @@ def identifyJavaDir(java_path_os_list):
                 JAVA variable path"""
     JavaExists = False
     i = 0
-    while(not JavaExists):
+    # Test some common folder paths to check whether a Java installation exists and stops once found
+    while(not JavaExists and i < len(java_path_os_list)):
         javaBaseDir = java_path_os_list[i]
         JavaExists = os.path.exists(javaBaseDir)
         i += 1
-    listJavaVersion = os.listdir(javaBaseDir)
-    listSplit = pd.Series({i: re.split('\.|\-', v) for i, v in enumerate(listJavaVersion)})
-    df_version = pd.DataFrame({"version": [listSplit[i][1] \
-                                            for i in listSplit.index],
-                                "startWith": [listSplit[i][0] \
-                                                for i in listSplit.index]})
-    highestVersion = df_version[(df_version.startWith == "java")\
-                                 | (df_version.startWith == "jdk")\
-                                 | (df_version.startWith == "jre1")].version.astype(int).idxmax()
-    javaPath = os.path.join(javaBaseDir, listJavaVersion[highestVersion])
+    if JavaExists:
+        listJavaVersion = os.listdir(javaBaseDir)
+        listSplit = pd.Series({i: re.split('\.|\-', v) for i, v in enumerate(listJavaVersion)})
+        df_version = pd.DataFrame({"version": [listSplit[i][1] \
+                                                for i in listSplit.index],
+                                    "startWith": [listSplit[i][0] \
+                                                    for i in listSplit.index]})
+        highestVersion = df_version[(df_version.startWith == "java")\
+                                     | (df_version.startWith == "jdk")\
+                                     | (df_version.startWith == "jre1")].version.astype(int).idxmax()
+        javaPath = os.path.join(javaBaseDir, listJavaVersion[highestVersion])
+    else:
+        javaPath = None
     
     return javaPath

--- a/urock_processing_algorithm.py
+++ b/urock_processing_algorithm.py
@@ -47,7 +47,8 @@ from qgis.core import (QgsProcessing,
                        QgsProject,
                        QgsProcessingContext,
                        QgsProcessingParameterEnum,
-                       QgsProcessingParameterFile)
+                       QgsProcessingParameterFile,
+                       QgsProcessingException)
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.utils import iface
 from pathlib import Path
@@ -127,10 +128,16 @@ class URockAlgorithm(QgsProcessingAlgorithm):
         
         # Get the default value of the Java environment path if already exists
         javaDirDefault = getJavaDir(plugin_directory)
+        print("javaDirDefault is :"+javaDirDefault)
+        print(type(javaDirDefault))
+        
+        # Raise an error if could not find a Java installation
+        if not javaDirDefault:
+            raise QgsProcessingException("No Java installation found")            
         
         # Inform the user that the Java version should be 64 bits
         if "Program Files (x86)" in javaDirDefault:
-            iface.ValueError(""""Only a 32 bits version of Java has been found \
+            raise QgsProcessingException(""""Only a 32 bits version of Java has been found \
                              on your computer. Please consider installing Java 64 bits.""")
         else:
             # Set a Java dir if not exist and save it into a file in the plugin repository
@@ -345,7 +352,7 @@ class URockAlgorithm(QgsProcessingAlgorithm):
                 veg_file = veg_file.split("|layername")[0]
             srid_veg = inputVegetationlayer.crs().postgisSrid()
             if srid_build != srid_veg:
-                feedback.pushInfo('Coordinate system of input building layer and vegetation layer differ!')
+                feedback.pushWarning('Coordinate system of input building layer and vegetation layer differ!')
         else:
             veg_file = None
             srid_veg = None
@@ -373,19 +380,19 @@ class URockAlgorithm(QgsProcessingAlgorithm):
             if os.path.exists(Path(outputDirectory).parent.absolute()):
                 os.mkdir(outputDirectory)
             else:
-                feedback.pushInfo('The output directory does not exist, neither its parent directory')
+                raise QgsProcessingException('The output directory does not exist, neither its parent directory')
 
         # If there is an output raster, need to get some of its parameters
         if outputRaster:
             if inputBuildinglayer.crs().postgisSrid() != outputRaster.crs().postgisSrid():
-                feedback.pushInfo('Coordinate system of input building layer and output Raster layer differ!')
+                feedback.pushWarning('Coordinate system of input building layer and output Raster layer differ!')
             xres = (outputRaster.extent().xMaximum() - outputRaster.extent().xMinimum()) / outputRaster.width()
             yres = (outputRaster.extent().yMaximum() - outputRaster.extent().yMinimum()) / outputRaster.height()               
             # If there is a raster and no meshSize, take the mean of x and y raster resolution
             if not meshSize:
                 meshSize = float(xres + yres) / 2
         elif not meshSize:
-            feedback.pushInfo('You should either specify an output raster or a horizontal mesh size')
+            raise QgsProcessingException('You should either specify an output raster or a horizontal mesh size')
             
         # Make the calculations
         u, v, w, u0, v0, w0, x, y, z, buildingCoordinates, cursor, gridName,\
@@ -442,7 +449,7 @@ class URockAlgorithm(QgsProcessingAlgorithm):
                                        "Wind at {0} m".format(z_i),
                                        "ogr")
                     if not loadedVector.isValid():
-                        feedback.pushInfo("Vector layer failed to load!")
+                        feedback.pushWarning("Vector layer failed to load!")
                         break
                     else:
                         loadedVector.loadNamedStyle(os.path.join(plugin_directory,\
@@ -463,7 +470,7 @@ class URockAlgorithm(QgsProcessingAlgorithm):
                                        "Wind speed at {0} m".format(z_i),
                                        "gdal")
                     if not loadedRaster.isValid():
-                        feedback.pushInfo("Raster layer failed to load!")
+                        feedback.pushWarning("Raster layer failed to load!")
                         break
                     else:
                         context.addLayerToLoadOnCompletion(loadedRaster.id(),

--- a/urock_processing_algorithm.py
+++ b/urock_processing_algorithm.py
@@ -48,7 +48,8 @@ from qgis.core import (QgsProcessing,
                        QgsProcessingContext,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterFile,
-                       QgsProcessingException)
+                       QgsProcessingException,
+                       QgsProcessingFeedback)
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.utils import iface
 from pathlib import Path
@@ -131,10 +132,11 @@ class URockAlgorithm(QgsProcessingAlgorithm):
         
         if not javaDirDefault:  # Raise an error if could not find a Java installation
             raise QgsProcessingException("No Java installation found")            
-        elif "Program Files (x86)" in javaDirDefault:   # Raise an error if could not find a 64 bits Java version
-            raise QgsProcessingException(""""Only a 32 bits version of Java has been found \
-                             on your computer. Please consider installing Java 64 bits.""")
-        else:   # Set a Java dir if not exist and save it into a file in the plugin repository
+        else:
+            if "Program Files (x86)" in javaDirDefault:   # Raise a warning if could not find a 64 bits Java version
+                raise QgsProcessingFeedback(""""Only a 32 bits version of Java has been found \
+                                            on your computer. Please consider replacing by Java 64 bits if you can.""")
+            # Set a Java dir if not exist and save it into a file in the plugin repository
             setJavaDir(javaDirDefault)
             saveJavaDir(javaPath = javaDirDefault,
                         pluginDirectory = plugin_directory)

--- a/urock_processing_algorithm.py
+++ b/urock_processing_algorithm.py
@@ -127,20 +127,14 @@ class URockAlgorithm(QgsProcessingAlgorithm):
         plugin_directory = self.plugin_dir = os.path.dirname(__file__)
         
         # Get the default value of the Java environment path if already exists
-        javaDirDefault = getJavaDir(plugin_directory)
-        print("javaDirDefault is :"+javaDirDefault)
-        print(type(javaDirDefault))
+        javaDirDefault = getJavaDir(plugin_directory)        
         
-        # Raise an error if could not find a Java installation
-        if not javaDirDefault:
+        if not javaDirDefault:  # Raise an error if could not find a Java installation
             raise QgsProcessingException("No Java installation found")            
-        
-        # Inform the user that the Java version should be 64 bits
-        if "Program Files (x86)" in javaDirDefault:
+        elif "Program Files (x86)" in javaDirDefault:   # Raise an error if could not find a 64 bits Java version
             raise QgsProcessingException(""""Only a 32 bits version of Java has been found \
                              on your computer. Please consider installing Java 64 bits.""")
-        else:
-            # Set a Java dir if not exist and save it into a file in the plugin repository
+        else:   # Set a Java dir if not exist and save it into a file in the plugin repository
             setJavaDir(javaDirDefault)
             saveJavaDir(javaPath = javaDirDefault,
                         pluginDirectory = plugin_directory)

--- a/urock_processing_algorithm.py
+++ b/urock_processing_algorithm.py
@@ -48,8 +48,7 @@ from qgis.core import (QgsProcessing,
                        QgsProcessingContext,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterFile,
-                       QgsProcessingException,
-                       QgsProcessingFeedback)
+                       QgsProcessingException)
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.utils import iface
 from pathlib import Path
@@ -133,9 +132,6 @@ class URockAlgorithm(QgsProcessingAlgorithm):
         if not javaDirDefault:  # Raise an error if could not find a Java installation
             raise QgsProcessingException("No Java installation found")            
         else:
-            if "Program Files (x86)" in javaDirDefault:   # Raise a warning if could not find a 64 bits Java version
-                raise QgsProcessingFeedback(""""Only a 32 bits version of Java has been found \
-                                            on your computer. Please consider replacing by Java 64 bits if you can.""")
             # Set a Java dir if not exist and save it into a file in the plugin repository
             setJavaDir(javaDirDefault)
             saveJavaDir(javaPath = javaDirDefault,
@@ -319,6 +315,7 @@ class URockAlgorithm(QgsProcessingAlgorithm):
         """
         Here is where the processing itself takes place.
         """
+        
         # Get the plugin directory to save some useful files
         plugin_directory = self.plugin_dir = os.path.dirname(__file__)
         
@@ -331,6 +328,11 @@ class URockAlgorithm(QgsProcessingAlgorithm):
         dz = self.parameterAsInt(parameters, self.VERTICAL_RESOLUTION, context)
         profileType = self.LIST_OF_PROFILES.loc[self.parameterAsInt(parameters, self.INPUT_PROFILE_TYPE, context)]
         profileFile = self.parameterAsString(parameters, self.INPUT_PROFILE_FILE, context)
+        
+        # Push a warning if could not find a 64 bits Java version
+        if "Program Files (x86)" in javaEnvVar:
+            feedback.pushWarning(""""Only a 32 bits version of Java has been found \
+                                 on your computer. Please consider replacing by Java 64 bits if you can.""")
         
         # Get building layer and then file directory
         inputBuildinglayer = self.parameterAsVectorLayer(parameters, self.BUILDING_TABLE_NAME, context)

--- a/urock_processing_algorithm.py
+++ b/urock_processing_algorithm.py
@@ -134,9 +134,7 @@ class URockAlgorithm(QgsProcessingAlgorithm):
             raise QgsProcessingException("No Java installation found")            
         elif ("Program Files (x86)" in javaDirDefault) and (struct.calcsize("P") * 8 != 32):
             # Raise an error if Java is 32 bits but Python 64 bits
-            raise QgsProcessingException("""Only a 32 bits version of Java has been found
-                                         while your Python installation is 64 bits.
-                                         Consider installing a 64 bits Java version.""")
+            raise QgsProcessingException("""Only a 32 bits version of Java has been found while your Python installation is 64 bits. Consider installing a 64 bits Java version.""")
         else:   # Set a Java dir if not exist and save it into a file in the plugin repository
             setJavaDir(javaDirDefault)
             saveJavaDir(javaPath = javaDirDefault,


### PR DESCRIPTION
Raise errors using the "QgsProcessingException" class instead of feedback.pushInfo. Also replace feedback.pushInfo by push warning when appropriate.

Now raise exceptions when only a Java 32 bits installation exists with a 64 bits Python installation and when there is no Java installation at all